### PR TITLE
Added support for traditional netcat to recognize open TCP ports.

### DIFF
--- a/bin/nodeset-accessible
+++ b/bin/nodeset-accessible
@@ -28,7 +28,7 @@ end
 
 def ssh_listen(node, port = 22)
   output = `netcat -zv #{node} #{port} 2>&1`
-  success = output.include? 'succeeded'
+  success = (output =~ /open|succeeded/)
   state = success ? 'listen' : 'closed'
   "#{node}:#{state}"
 end


### PR DESCRIPTION
Hi Victor,

using the traditional netcat version returns **open** in the returned output when a TCP connection could be established.

This is not the case when using the the OpenBSD netcat version. 
There the keyword **succeeded** is returned instead in the output string.

Regards,
Gabriele