### PR TITLE
[DOCS] Add short note about 'apt-cache madison'

### DIFF
--- a/docs/apt.md
+++ b/docs/apt.md
@@ -27,6 +27,7 @@ apt-get -f install | dpkg --configure -a      # recover from broken installation
 dpkg-query -l                                 # list all installed packages
 dpkg -s <package> | grep ^Version             # show installed version of package
 apt-cache policy <package> | grep -i installed
+apt-cache madison <package>                   # list all available package versions in the repositories (binary + sources)
 dpkg -L <package>                             # list content of a package (if installed)
 dpkg -S <path>                                # find package containing file (if installed)
 debsums -ce                                   # find configuration files changed from default 


### PR DESCRIPTION
Add a note about the 'madison' option for apt-cache.

Output example:

```bash
apt-cache madison bash
bash | 4.3-11+deb8u1 | http://ftp.XX.debian.org/debian/ jessie/main amd64 Packages
bash | 4.3-11+deb8u1 | http://ftp.XX.debian.org/debian/ jessie/main Sources
```